### PR TITLE
Add core editor components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+package-lock.json

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,39 @@
-import React from 'react'
+import { useState } from "react";
+import Sidebar from "./components/Sidebar";
+import EditorPane from "./components/EditorPane";
+import PreviewPane from "./components/PreviewPane";
+
+const sectionTemplates = {
+  personal: { name: "", email: "", phone: "" },
+  summary: { text: "" }
+};
 
 export default function App() {
+  const [sections, setSections] = useState([
+    { id: "personal", title: "Dados Pessoais", data: sectionTemplates.personal },
+    { id: "summary",  title: "Resumo",         data: sectionTemplates.summary  }
+  ]);
+  const [activeId, setActiveId] = useState("personal");
+
+  const handleSectionChange = (newData) => {
+    setSections(prev =>
+      prev.map(s => s.id === activeId ? { ...s, data: newData } : s)
+    );
+  };
+
+  const activeSection = sections.find(s => s.id === activeId);
+
   return (
-    <div className="min-h-screen flex">
-      <aside className="w-[250px] bg-gray-800 text-white p-4">
-        Sidebar
-      </aside>
-      <main className="flex-1 p-4">
-        Main Content
-      </main>
+    <div className="h-screen grid grid-cols-[250px_1fr]">
+      <Sidebar
+        sections={sections}
+        activeId={activeId}
+        onSelect={setActiveId}
+      />
+      <div className="grid grid-cols-2 gap-4 p-4 overflow-auto">
+        <EditorPane section={activeSection} onChange={handleSectionChange} />
+        <PreviewPane sections={sections} />
+      </div>
     </div>
-  )
+  );
 }

--- a/src/components/EditorPane.jsx
+++ b/src/components/EditorPane.jsx
@@ -1,0 +1,43 @@
+export default function EditorPane({ section, onChange }) {
+  if (!section) return null;
+  const { id, data } = section;
+
+  const update = (field, value) => onChange({ ...data, [field]: value });
+
+  switch (id) {
+    case "personal":
+      return (
+        <div className="space-y-3">
+          <input
+            className="input"
+            placeholder="Nome"
+            value={data.name}
+            onChange={e => update("name", e.target.value)}
+          />
+          <input
+            className="input"
+            placeholder="E-mail"
+            value={data.email}
+            onChange={e => update("email", e.target.value)}
+          />
+          <input
+            className="input"
+            placeholder="Telefone"
+            value={data.phone}
+            onChange={e => update("phone", e.target.value)}
+          />
+        </div>
+      );
+    case "summary":
+      return (
+        <textarea
+          className="input h-40"
+          placeholder="Resumo profissional"
+          value={data.text}
+          onChange={e => update("text", e.target.value)}
+        />
+      );
+    default:
+      return <p className="text-gray-500">Seção não suportada ainda.</p>;
+  }
+}

--- a/src/components/PreviewPane.jsx
+++ b/src/components/PreviewPane.jsx
@@ -1,0 +1,21 @@
+export default function PreviewPane({ sections }) {
+  const personal = sections.find(s => s.id === "personal")?.data || {};
+  const summary  = sections.find(s => s.id === "summary")?.data || {};
+
+  return (
+    <div className="prose max-w-none border rounded p-6 bg-white shadow">
+      {personal.name && <h1 className="m-0">{personal.name}</h1>}
+      {(personal.email || personal.phone) && (
+        <p className="mt-0 text-sm text-gray-600">
+          {personal.email} {personal.email && personal.phone && "\u2022"} {personal.phone}
+        </p>
+      )}
+      {summary.text && (
+        <>
+          <h2>Resumo</h2>
+          <p>{summary.text}</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,18 @@
+export default function Sidebar({ sections, activeId, onSelect }) {
+  return (
+    <aside className="bg-gray-100 dark:bg-gray-800 p-4 space-y-2">
+      {sections.map(({ id, title }) => (
+        <button
+          key={id}
+          onClick={() => onSelect(id)}
+          className={`w-full text-left px-3 py-2 rounded
+            ${id === activeId
+              ? "bg-blue-500 text-white"
+              : "hover:bg-gray-200 dark:hover:bg-gray-700"}`}
+        >
+          {title}
+        </button>
+      ))}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold Sidebar component for navigation
- add EditorPane for editing content
- implement PreviewPane to show resume preview
- orchestrate components inside App
- add `.gitignore`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68646b74bdb48325bd592d838893530c