### PR TITLE
Fix base path condition for Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  base: '/cv-builder/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/cv-builder/' : '/',
   plugins: [react()],
-})
+}))


### PR DESCRIPTION
## Summary
- make Vite use `/cv-builder/` base path only during production builds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68646f3380708325975e318a65915e84